### PR TITLE
create build.properties, factor out execution context

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -4,7 +4,6 @@ import generators.{ Generator, MvnGenerator, SbtGenerator }
 import models.{ BuildTool, ProjectDescription }
 import play.api.mvc._
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import generators.GradleGenerator
 
@@ -50,6 +49,8 @@ class Application extends Controller {
     } yield {
       ProjectDescription(proj, tool, lang, name, organization)
     }
+
+    import global.Dispatchers.ioDispatcher
 
     errorOrDesc.fold(
       error => Future.successful(BadRequest(error)),

--- a/app/generators/Generator.scala
+++ b/app/generators/Generator.scala
@@ -4,7 +4,7 @@ import models._
 import java.io.File
 import java.nio.file._
 import java.nio.file.attribute.BasicFileAttributes
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Random
 import java.util.{ HashMap => jHashMap }
 import java.net.URI
@@ -13,11 +13,9 @@ import java.io.IOException
 trait Generator {
   import Generator._
 
-  import global.Dispatchers.ioDispatcher
+  def generate(projectDescription: ProjectDescription)(implicit ec: ExecutionContext): Future[File]
 
-  def generate(projectDescription: ProjectDescription): Future[File]
-
-  def makeProjectBase(projectType: ProjectType): Future[File] = {
+  def makeProjectBase(projectType: ProjectType)(implicit ec: ExecutionContext): Future[File] = {
     def mapProjectType(pt: ProjectType): String = pt match {
       case models.Play => PlayResources
       case _ => StandardResources
@@ -40,7 +38,7 @@ trait Generator {
   /**
    * Zip the given folder, delete the folder and return the zip file.
    */
-  def zip(folder: File, folderName: String): Future[File] = {
+  def zip(folder: File, folderName: String)(implicit ec: ExecutionContext): Future[File] = {
     Future {
       val folderToZip = folder.toPath()
 

--- a/app/generators/GradleGenerator.scala
+++ b/app/generators/GradleGenerator.scala
@@ -1,16 +1,15 @@
 package generators
 
 import models.ProjectDescription
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 import java.io.File
-import global.Dispatchers.ioDispatcher
 import java.nio.file.Files
 import java.nio.charset.StandardCharsets
 import models.ProjectDescription
 
 object GradleGenerator extends Generator {
 
-  def generate(projectDescription: ProjectDescription): Future[File] = {
+  def generate(projectDescription: ProjectDescription)(implicit ec: ExecutionContext): Future[File] = {
     makeProjectBase(projectDescription.projectType).map { folder =>
       val gradleBuildContent: String = txt.gradle_build.render(projectDescription).body
       val gradleBuildFile = folder.toPath().resolve("build.gradle")

--- a/app/generators/MvnGenerator.scala
+++ b/app/generators/MvnGenerator.scala
@@ -6,13 +6,11 @@ import java.nio.file.Files
 
 import models.ProjectDescription
 
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 object MvnGenerator extends Generator {
 
-  import global.Dispatchers.ioDispatcher
-
-  def generate(projectDescription: ProjectDescription): Future[File] = {
+  def generate(projectDescription: ProjectDescription)(implicit ec: ExecutionContext): Future[File] = {
     makeProjectBase(projectDescription.projectType) flatMap { folder =>
       val pomXmlContent: String = xml.pom.render(projectDescription).body
 

--- a/test/generators/SbtGeneratorSpec.scala
+++ b/test/generators/SbtGeneratorSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest._
 
 import scala.concurrent._
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class SbtGeneratorSpec extends FunSpec with Matchers {
 


### PR DESCRIPTION
Factored out the execution context (now passed to generator methods as impl. parameter), also added generation of build.properties.
